### PR TITLE
Fix for go 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cert-manager/goversion
+
+go 1.17

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"rsc.io/goversion/version"
+	"github.com/cert-manager/goversion/version"
 )
 
 var (

--- a/version/read.go
+++ b/version/read.go
@@ -57,10 +57,10 @@ func ReadExe(file string) (Version, error) {
 			v.Release = release
 
 		}
-		if strings.Contains(name, "_Cfunc__goboringcrypto_") || name == "crypto/internal/boring/sig.BoringCrypto" {
+		if strings.Contains(name, "_Cfunc__goboringcrypto_") || strings.HasPrefix(name, "crypto/internal/boring/sig.BoringCrypto") {
 			v.BoringCrypto = true
 		}
-		if name == "crypto/internal/boring/sig.FIPSOnly" {
+		if strings.HasPrefix(name, "crypto/internal/boring/sig.FIPSOnly") {
 			v.FIPSOnly = true
 		}
 		for _, re := range standardCryptoNames {


### PR DESCRIPTION
This PR:

- allows goversion to detect FIPS-only TLS for Go 1.17+ (code for that is borrowed from https://github.com/rsc/goversion/pull/21/commits/42d9398b0959b0342b4ff4087622c118cc164f69)
- go mod tidy & go mod init

To test that this change works you can follow steps in fips-builds (Jetstack internal project) Readme against a fips version of cert-manager built with Go 1.17+ i.e v1.7.2 https://github.com/jetstack/fips-builds#verifying-the-images to verify that the build is/isnt' built with FIPS only TLS enforced